### PR TITLE
Migrate mailer and reqarchive off aws-sdk-go v1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,10 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.29
 	github.com/Azure/go-autorest/autorest/adal v0.9.23
 	github.com/aws/aws-sdk-go v1.44.287
+	github.com/aws/aws-sdk-go-v2 v1.43.3
 	github.com/aws/aws-sdk-go-v2/config v1.32.34
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.4
+	github.com/aws/aws-sdk-go-v2/service/ses v1.37.3
 	github.com/dustin/go-humanize v1.0.1
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/uuid v1.6.0
@@ -42,7 +44,6 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.43.3 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.16 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.33 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.34 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.35 h1:ohfdSAm4TA6nr
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.35/go.mod h1:uUjphnxMb3HH3vIiOHl4dH0fGNKL+csjqRQEabbfw5k=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.106.4 h1:nN+nb2rhWmPOMwFA+e6xDJZJ0h/VAI39XVBzn52Fn8A=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.106.4/go.mod h1:lWk6L5Q3YkaC7so1bQUJkvF7hj2KUFzdZ4w15wc2GHY=
+github.com/aws/aws-sdk-go-v2/service/ses v1.37.3 h1:FlRrHjPW7AhQFIrnUd4GzmZvXi5uOlAImlc7l4BOIcw=
+github.com/aws/aws-sdk-go-v2/service/ses v1.37.3/go.mod h1:hhvmps5VHqNABpz3qk85az80vCXjD35yeNCDU+GQDoE=
 github.com/aws/aws-sdk-go-v2/service/signin v1.5.3 h1:togAtAmgV5IGMnQDuBDJeM8z5Y5RN6G7xeOgphWz+Yc=
 github.com/aws/aws-sdk-go-v2/service/signin v1.5.3/go.mod h1:T7xKUUUvN7W3RW8UmMvKnD12xqh+Ux2gCPHPhnt64Dg=
 github.com/aws/aws-sdk-go-v2/service/sso v1.33.3 h1:YjH64OUytnWZBHUtM9GMyi4ZWBiSQdEJkZuPykOIe44=

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -9,9 +9,10 @@ import (
 	"mime/multipart"
 	"net/textproto"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ses"
+	"github.com/aws/aws-sdk-go-v2/service/ses/types"
 )
 
 const (
@@ -22,21 +23,19 @@ const (
 // SES sends email notifications via AWS SES.
 type SES struct {
 	sender string
-	svc    *ses.SES
+	svc    *ses.Client
 }
 
 // NewSES constructs a new mailer that uses AWS SES to send emails.
 func NewSES(region string, sender string) (*SES, error) {
-	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String(region)},
-	)
+	cfg, err := config.LoadDefaultConfig(context.Background(),
+		config.WithRegion(region))
 	if err != nil {
 		return nil, err
 	}
-	svc := ses.New(sess)
 	return &SES{
 		sender: sender,
-		svc:    svc,
+		svc:    ses.NewFromConfig(cfg),
 	}, nil
 }
 
@@ -44,20 +43,18 @@ func NewSES(region string, sender string) (*SES, error) {
 func (m *SES) Send(ctx context.Context, content string, email string, subject string) error {
 	// Assemble the email.
 	input := &ses.SendEmailInput{
-		Destination: &ses.Destination{
-			CcAddresses: []*string{},
-			ToAddresses: []*string{
-				aws.String(email),
-			},
+		Destination: &types.Destination{
+			CcAddresses: []string{},
+			ToAddresses: []string{email},
 		},
-		Message: &ses.Message{
-			Body: &ses.Body{
-				Html: &ses.Content{
+		Message: &types.Message{
+			Body: &types.Body{
+				Html: &types.Content{
 					Charset: aws.String(CharSet),
 					Data:    aws.String(content),
 				},
 			},
-			Subject: &ses.Content{
+			Subject: &types.Content{
 				Charset: aws.String(CharSet),
 				Data:    aws.String(subject),
 			},
@@ -65,7 +62,7 @@ func (m *SES) Send(ctx context.Context, content string, email string, subject st
 		Source: aws.String(m.sender),
 	}
 	// Attempt to send the email.
-	_, err := m.svc.SendEmailWithContext(ctx, input)
+	_, err := m.svc.SendEmail(ctx, input)
 	if err != nil {
 		return err
 	}
@@ -126,11 +123,11 @@ func (m *SES) SendWithAttachment(ctx context.Context, body, to, subject string, 
 	}
 
 	input := &ses.SendRawEmailInput{
-		RawMessage: &ses.RawMessage{
+		RawMessage: &types.RawMessage{
 			Data: msg.Bytes(),
 		},
 	}
 
-	_, err := m.svc.SendRawEmailWithContext(ctx, input)
+	_, err := m.svc.SendRawEmail(ctx, input)
 	return err
 }

--- a/reqarchive/s3.go
+++ b/reqarchive/s3.go
@@ -10,9 +10,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awscfg "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/luthersystems/svc/midware"
 	"github.com/sirupsen/logrus"
 )


### PR DESCRIPTION
## Summary

- Migrates `mailer` (SES client) from the deprecated aws-sdk-go v1 to aws-sdk-go-v2: `config.LoadDefaultConfig` + `ses.NewFromConfig`, context-first `SendEmail`/`SendRawEmail`, typed `types.Destination`/`types.Message` inputs.
- Swaps `reqarchive`'s one remaining v1 import (`aws.String`) for the v2 `aws` package.
- No exported API changes: `NewSES`, `Send`, `SendWithAttachment`, and `Attachment` keep the same signatures, so this is non-breaking for consumers. lutherauth's magiclink server (the motivating consumer) drops the deprecated v1 SDK from its binary once it bumps to a release containing this.

## Not included

`docstore/s3` still uses v1 because `NewWithSession` exposes `*session.Session` in its exported API — migrating it changes the public API and needs its own coordinated PR. After this lands, `docstore/s3` is the only v1 usage left in svc.

## Test plan

- `go build ./...`, `go vet ./...` clean
- `go test ./mailer/... ./reqarchive/... ./docstore/...` pass
- `golangci-lint run` — 0 issues
- Wire behavior is unchanged: same SES `SendEmail`/`SendRawEmail` operations, same IAM permissions; the v2 default credential chain covers env vars, shared config, IMDS, and IRSA.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sdr7gadsurqY9Xh9FFJkHY)_