### PR TITLE
Add on-demand release workflow (workflow_dispatch)

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,88 @@
+name: Release (tag)
+
+# On-demand release cut, dispatched by an operator (or an agent the operator
+# directed) from the Actions UI or `gh workflow run`. This is a library repo
+# with no tag-triggered pipelines, so the default GITHUB_TOKEN can create the
+# tag + release directly — no app token needed (contrast lutherauth/buildenv,
+# whose tags must trigger docker publish workflows and therefore release via
+# the Claude App; see lutherauth/.github/workflows/release-tag.yml).
+#
+# Leave `version` empty to auto-bump the patch component of the latest
+# vMAJOR.MINOR.PATCH tag; pass an explicit version for minor/major bumps.
+# Always cuts from main HEAD.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to tag (vMAJOR.MINOR.PATCH). Empty = auto-bump patch of the latest tag."
+        type: string
+        required: false
+        default: ""
+      dry_run:
+        description: "Print the computed version but do NOT cut the release"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write # gh release create (creates the tag + release)
+
+concurrency:
+  group: release-tag
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Cut release
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # all tags, for latest-version detection
+      - name: Compute and validate version
+        id: ver
+        env:
+          REQUESTED: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          latest=$(git tag --list 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 || true)
+          if [ -n "$REQUESTED" ]; then
+            version="$REQUESTED"
+          elif [ -n "$latest" ]; then
+            IFS=. read -r major minor patch <<<"${latest#v}"
+            version="v${major}.${minor}.$((patch + 1))"
+          else
+            echo "error: no existing vMAJOR.MINOR.PATCH tag to bump from; pass an explicit version" >&2
+            exit 1
+          fi
+          echo "$version" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' || {
+            echo "error: version '$version' is not vMAJOR.MINOR.PATCH" >&2
+            exit 1
+          }
+          if [ -n "$latest" ]; then
+            newest=$(printf '%s\n%s\n' "$latest" "$version" | sort -V | tail -n1)
+            if [ "$newest" != "$version" ] || [ "$version" = "$latest" ]; then
+              echo "error: version $version is not strictly newer than latest tag $latest" >&2
+              exit 1
+            fi
+          fi
+          echo "computed version: $version (latest existing: ${latest:-none})"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Dry run — print only
+        if: ${{ inputs.dry_run }}
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: echo "DRY RUN — would release $VERSION from $GITHUB_SHA; nothing created."
+      - name: Cut release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --target "$GITHUB_SHA" \
+            --generate-notes
+          echo "released $VERSION at $GITHUB_SHA"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release-tag.yml`: an on-demand release cut, dispatched from the Actions UI or `gh workflow run` (which agents can trigger — the motivating case was being unable to push the `v0.15.1` tag from a sandbox after #82 merged).

- `version` input empty → auto-bumps the **patch** of the latest `vX.Y.Z` tag; pass an explicit version for minor/major.
- Validates strict `vMAJOR.MINOR.PATCH` shape and that the version is strictly newer than the latest tag; always cuts from `main` HEAD.
- `dry_run` input prints the computed version without creating anything.
- Uses the default `GITHUB_TOKEN` — this repo has no tag-triggered pipelines, so no app-token indirection is needed (contrast lutherauth's `release-tag.yml`, whose tag must fire a docker publish workflow).

## Test plan

- YAML parses; the version-computation shell was syntax-checked with `bash -n`.
- First real exercise will be cutting `v0.15.1` (the aws-sdk-go-v2 mailer migration) after this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sdr7gadsurqY9Xh9FFJkHY)_