### PR TITLE
lint: exclude SA1019 aws-sdk-go deprecation in docstore/s3

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,3 +4,14 @@ run:
 linters:
   enable:
     - gosec
+  exclusions:
+    rules:
+      # aws-sdk-go v1 deprecation (SA1019): docstore/s3 is the last v1
+      # consumer — its exported NewWithSession takes a v1 *session.Session,
+      # so migrating to aws-sdk-go-v2 is a breaking API change that needs
+      # its own coordinated PR (mailer/reqarchive migrated in #82). Without
+      # this exclusion any Dependabot bump of aws-sdk-go >= 1.55 reds CI on
+      # the deprecation markers alone.
+      - path: docstore/s3/s3\.go
+        linters: [staticcheck]
+        text: "SA1019"


### PR DESCRIPTION
## Summary

aws-sdk-go ≥ 1.55 stamps `Deprecated:` markers on every package, so any Dependabot bump of the v1 SDK now reds CI on staticcheck SA1019 in `docstore/s3` — the last v1 consumer (that's exactly why #80's build job failed). The v2 migration for `docstore/s3` is a breaking API change (`NewWithSession` exposes a v1 `*session.Session`) tracked as follow-up to #82, so until that lands the deprecation warning alone shouldn't block dep bumps.

Adds a path-scoped SA1019 exclusion for `docstore/s3/s3.go` only, mirroring the precedent lutherauth used for the same situation pre-migration.

After this merges, #80 gets a `·@·d·ependabot r·ebase` and should go green.

## Test plan

- `golangci-lint config verify` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sdr7gadsurqY9Xh9FFJkHY)_