### PR TITLE
Migrate docstore/s3 to aws-sdk-go-v2, removing aws-sdk-go v1 entirely

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,14 +4,3 @@ run:
 linters:
   enable:
     - gosec
-  exclusions:
-    rules:
-      # aws-sdk-go v1 deprecation (SA1019): docstore/s3 is the last v1
-      # consumer — its exported NewWithSession takes a v1 *session.Session,
-      # so migrating to aws-sdk-go-v2 is a breaking API change that needs
-      # its own coordinated PR (mailer/reqarchive migrated in #82). Without
-      # this exclusion any Dependabot bump of aws-sdk-go >= 1.55 reds CI on
-      # the deprecation markers alone.
-      - path: docstore/s3/s3\.go
-        linters: [staticcheck]
-        text: "SA1019"

--- a/docstore/s3/s3.go
+++ b/docstore/s3/s3.go
@@ -5,54 +5,62 @@ package s3
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/client"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/luthersystems/svc/docstore"
 	"github.com/sirupsen/logrus"
 )
 
-type missingRetryer struct {
-	client.DefaultRetryer
-}
-
 var _ docstore.DocStore = &Store{}
 
-func (retryer missingRetryer) ShouldRetry(req *request.Request) bool {
-	if req.HTTPResponse.StatusCode == 404 {
-		return true
-	}
-	return retryer.DefaultRetryer.ShouldRetry(req)
+// maxAttempts preserves the legacy DefaultRetryer{NumMaxRetries: 5}
+// behaviour (1 initial attempt + 5 retries).
+const maxAttempts = 6
+
+// missingRetryer retries GetObject calls that fail with NoSuchKey for
+// roughly a second, to avoid issues when rapidly writing and reading
+// objects (the legacy custom retryer's 404 behaviour).
+func missingRetryer() aws.Retryer {
+	return retry.AddWithErrorCodes(
+		retry.AddWithMaxAttempts(retry.NewStandard(), maxAttempts),
+		(&types.NoSuchKey{}).ErrorCode(),
+	)
+}
+
+func standardRetryer() aws.Retryer {
+	return retry.AddWithMaxAttempts(retry.NewStandard(), maxAttempts)
 }
 
 // New returns a new Store configured for the specified bucket and prefix.
 func New(region string, bucket string, prefix string) (*Store, error) {
-	sess, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	cfg, err := config.LoadDefaultConfig(context.Background(),
+		config.WithRegion(region))
 	if err != nil {
 		return nil, err
 	}
-	svc := s3.New(sess)
-	return &Store{bucket, prefix, svc}, nil
+	return NewFromConfig(cfg, bucket, prefix), nil
 }
 
-// NewWithSession returns a new Store configured for the specified session.
-func NewWithSession(sess *session.Session, bucket string, prefix string) (*Store, error) {
-	svc := s3.New(sess)
-	return &Store{bucket, prefix, svc}, nil
+// NewFromConfig returns a new Store using the supplied aws-sdk-go-v2
+// configuration. It replaces the legacy NewWithSession constructor, which
+// took an aws-sdk-go (v1) *session.Session.
+func NewFromConfig(cfg aws.Config, bucket string, prefix string) *Store {
+	return &Store{bucket, prefix, s3.NewFromConfig(cfg)}
 }
 
 // Store is an S3 implementation of a DocStore.
 type Store struct {
 	bucket string
 	prefix string
-	svc    *s3.S3
+	svc    *s3.Client
 }
 
 // Put writes bytes to an S3 object.
@@ -63,20 +71,39 @@ func (a *Store) Put(ctx context.Context, key string, body []byte) error {
 	}
 
 	input := &s3.PutObjectInput{
-		Body:   aws.ReadSeekCloser(bytes.NewReader(body)),
+		Body:   bytes.NewReader(body),
 		Bucket: aws.String(a.bucket),
 		Key:    aws.String(fmt.Sprintf("%s/%s", a.prefix, key)),
 	}
 
-	request, _ := a.svc.PutObjectRequest(input)
-	request.Retryer = client.DefaultRetryer{NumMaxRetries: 5}
-	request.SetContext(ctx)
-	err = request.Send()
+	_, err = a.svc.PutObject(ctx, input, func(o *s3.Options) {
+		o.Retryer = standardRetryer()
+	})
 	if err != nil {
 		return fmt.Errorf("s3 put: %w", err)
 	}
 
 	return nil
+}
+
+func (a *Store) getObject(ctx context.Context, key string) (*s3.GetObjectOutput, error) {
+	input := &s3.GetObjectInput{
+		Bucket: aws.String(a.bucket),
+		Key:    aws.String(fmt.Sprintf("%s/%s", a.prefix, key)),
+	}
+	// retry requests that aren't in S3 for about 1 second to avoid issues
+	// when rapidly writing and reading requests
+	result, err := a.svc.GetObject(ctx, input, func(o *s3.Options) {
+		o.Retryer = missingRetryer()
+	})
+	if err != nil {
+		var noSuchKey *types.NoSuchKey
+		if errors.As(err, &noSuchKey) {
+			return nil, docstore.ErrRequestNotFound
+		}
+		return nil, fmt.Errorf("s3 get: %w", err)
+	}
+	return result, nil
 }
 
 // Get reads bytes stored in an S3 document.
@@ -85,25 +112,15 @@ func (a *Store) Get(ctx context.Context, key string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	input := &s3.GetObjectInput{
-		Bucket: aws.String(a.bucket),
-		Key:    aws.String(fmt.Sprintf("%s/%s", a.prefix, key)),
-	}
-	request, result := a.svc.GetObjectRequest(input)
-	// retry requests that aren't in S3 for about 1 second to avoid issues
-	// when rapidly writing and reading requests
-	request.Retryer = missingRetryer{client.DefaultRetryer{NumMaxRetries: 5}}
-	request.SetContext(ctx)
-	err = request.Send()
+	result, err := a.getObject(ctx, key)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case s3.ErrCodeNoSuchKey:
-				return nil, docstore.ErrRequestNotFound
-			}
-		}
-		return nil, fmt.Errorf("s3 get: %w", err)
+		return nil, err
 	}
+	defer func() {
+		if err := result.Body.Close(); err != nil {
+			logrus.WithError(err).Warn("get: close")
+		}
+	}()
 	body, err := io.ReadAll(result.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read result body: %w", err)
@@ -114,32 +131,23 @@ func (a *Store) Get(ctx context.Context, key string) ([]byte, error) {
 // GetStreaming streams an S3 document's bytes into the supplied
 // http.ResponseWriter
 func (a *Store) GetStreaming(key string, w http.ResponseWriter) error {
-	input := &s3.GetObjectInput{
-		Bucket: aws.String(a.bucket),
-		Key:    aws.String(fmt.Sprintf("%s/%s", a.prefix, key)),
-	}
-	request, result := a.svc.GetObjectRequest(input)
-	// retry requests that aren't in S3 for about 1 second to avoid issues
-	// when rapidly writing and reading requests
-	request.Retryer = missingRetryer{client.DefaultRetryer{NumMaxRetries: 5}}
-	if err := request.Send(); err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case s3.ErrCodeNoSuchKey:
-				return docstore.ErrRequestNotFound
-			}
-		}
-		return fmt.Errorf("s3 get: %w", err)
+	result, err := a.getObject(context.Background(), key)
+	if err != nil {
+		return err
 	}
 	w.Header().Set("Connection", "close")
-	w.Header().Set("Content-Type", *(result.ContentType))
-	w.Header().Set("Content-Length", fmt.Sprintf("%d", *(result.ContentLength)))
+	if result.ContentType != nil {
+		w.Header().Set("Content-Type", *result.ContentType)
+	}
+	if result.ContentLength != nil {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", *result.ContentLength))
+	}
 	defer func() {
 		if err := result.Body.Close(); err != nil {
 			logrus.WithError(err).Warn("get streaming: close")
 		}
 	}()
-	_, err := io.Copy(w, result.Body)
+	_, err = io.Copy(w, result.Body)
 	if err != nil {
 		return fmt.Errorf("s3 get: %w", err)
 	}
@@ -158,13 +166,11 @@ func (a *Store) Delete(ctx context.Context, key string) error {
 		Key:    aws.String(fmt.Sprintf("%s/%s", a.prefix, key)),
 	}
 
-	_, err = a.svc.DeleteObjectWithContext(ctx, input)
+	_, err = a.svc.DeleteObject(ctx, input)
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			case s3.ErrCodeNoSuchKey:
-				return docstore.ErrRequestNotFound
-			}
+		var noSuchKey *types.NoSuchKey
+		if errors.As(err, &noSuchKey) {
+			return docstore.ErrRequestNotFound
 		}
 		return fmt.Errorf("s3 delete: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Azure/azure-storage-blob-go v0.15.0
 	github.com/Azure/go-autorest/autorest v0.11.30
 	github.com/Azure/go-autorest/autorest/adal v0.9.24
-	github.com/aws/aws-sdk-go v1.55.8
 	github.com/aws/aws-sdk-go-v2 v1.43.3
 	github.com/aws/aws-sdk-go-v2/config v1.32.34
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.4
@@ -70,7 +69,6 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-plugin v1.6.0 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-ieproxy v0.0.11 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,6 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
-github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/aws/aws-sdk-go-v2 v1.43.3 h1:XJIcfv8uDs2ukdQsoAC8/Ebu1ejxwzlayl2ZsiFns2A=
 github.com/aws/aws-sdk-go-v2 v1.43.3/go.mod h1:70vwSy16txshwG+g55WkpgPKDIByzHI8ccBsOteo3bQ=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.16 h1:aiuaKlDweRC5qExJondpWjOgyzMHpofpwspGXUtwn4c=
@@ -129,10 +127,6 @@ github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/jhump/protoreflect v1.15.1/go.mod h1:jD/2GMKKE6OqX8qTjhADU1e6DShO+gavG9e0Q693nKo=
-github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
-github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=


### PR DESCRIPTION
## Summary

Finishes what #82 started: `docstore/s3` was the last aws-sdk-go v1 consumer in the fleet, kept on v1 because its exported API leaked a v1 type. With this, `go.mod` drops `github.com/aws/aws-sdk-go` completely and the #84 SA1019 lint exclusion is removed.

**Breaking change (user-authorized):** `NewWithSession(*session.Session, bucket, prefix)` → `NewFromConfig(cfg aws.Config, bucket, prefix)`. `New(region, bucket, prefix)` keeps its exact signature, so consumers using the common constructor are unaffected; only callers passing a v1 session must switch to a v2 `aws.Config`. Suggest tagging the next release as **v0.16.0** to signal the API change.

Behavior preserved:
- The custom 404 retryer (retry `GetObject` `NoSuchKey` for ~1s to cover rapid write-then-read) maps to `retry.AddWithErrorCodes` on the standard retryer; `DefaultRetryer{NumMaxRetries: 5}` maps to `MaxAttempts: 6`.
- `NoSuchKey` still maps to `docstore.ErrRequestNotFound` (now via `errors.As`).

Two small correctness improvements that fell out: `Get` now closes the response body (the v1 code leaked the connection), and `GetStreaming` nil-guards `ContentType`/`ContentLength` instead of dereferencing unconditionally.

## Test plan

- `go build ./...`, `go vet ./...` clean; docstore/mailer/reqarchive tests pass; `golangci-lint run` — 0 issues with the exclusion deleted.
- `go mod why -m github.com/aws/aws-sdk-go` → "main module does not need module".
- Full `make citest` (oracle tests incl. substrate plugin) runs in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sdr7gadsurqY9Xh9FFJkHY)_